### PR TITLE
Make the test runnable from any location

### DIFF
--- a/tst/bgw.tst
+++ b/tst/bgw.tst
@@ -1,5 +1,7 @@
 gap> START_TEST( "Start highlevel tests" );
-gap> Read("tst/testpackage.g");;
+gap> testpackage := Filename( DirectoriesPackageLibrary( "DeepThought", "tst" ),
+>                             "testpackage.g" );;
+gap> Read(testpackage);;
 gap> coll := Collector(BurdeGrunewaldPcpGroup(0, 1));;
 gap> Test_DTP_functions(coll, true, 5, 10);
 true

--- a/tst/examples.tst
+++ b/tst/examples.tst
@@ -1,4 +1,6 @@
-gap> Read("tst/testpackage.g");;
+gap> testpackage := Filename( DirectoriesPackageLibrary( "DeepThought", "tst" ),
+>                             "testpackage.g" );;
+gap> Read(testpackage);;
 gap> coll :=  Collector(ExamplesOfSomePcpGroups(11));;
 gap> Test_DTP_functions(coll, true, 50, 100);
 true

--- a/tst/extended.tstlong
+++ b/tst/extended.tstlong
@@ -1,4 +1,6 @@
-gap> Read("tst/testpackage.g");;
+gap> testpackage := Filename( DirectoriesPackageLibrary( "DeepThought", "tst" ),
+>                             "testpackage.g" );;
+gap> Read(testpackage);;
 
 # example group 14: 
 gap> coll := Collector(ExamplesOfSomePcpGroups(14));; 

--- a/tst/finite.tst
+++ b/tst/finite.tst
@@ -1,4 +1,6 @@
-gap> Read("tst/testpackage.g");;
+gap> testpackage := Filename( DirectoriesPackageLibrary( "DeepThought", "tst" ),
+>                             "testpackage.g" );;
+gap> Read(testpackage);;
 
 # finite group 
 gap> p := 2;;

--- a/tst/heisenberg.tst
+++ b/tst/heisenberg.tst
@@ -1,4 +1,6 @@
-gap> Read("tst/testpackage.g");;
+gap> testpackage := Filename( DirectoriesPackageLibrary( "DeepThought", "tst" ),
+>                             "testpackage.g" );;
+gap> Read(testpackage);;
 gap> coll := Collector(HeisenbergPcpGroup(3));;
 gap> Test_DTP_functions(coll, true, 1000, 100);
 true

--- a/tst/random.tst
+++ b/tst/random.tst
@@ -1,4 +1,6 @@
-gap> Read("tst/testpackage.g");;
+gap> testpackage := Filename( DirectoriesPackageLibrary( "DeepThought", "tst" ),
+>                             "testpackage.g" );;
+gap> Read(testpackage);;
 
 # test random collector 
 gap> Test_DTP_functions(DTP_rand_coll(), true, 100, 1000);

--- a/tst/somecolls.tst
+++ b/tst/somecolls.tst
@@ -1,4 +1,6 @@
-gap> Read("tst/testpackage.g");;
+gap> testpackage := Filename( DirectoriesPackageLibrary( "DeepThought", "tst" ),
+>                             "testpackage.g" );;
+gap> Read(testpackage);;
 
 # test first collector 
 gap> coll := FromTheLeftCollector(4);;

--- a/tst/unitriangular.tst
+++ b/tst/unitriangular.tst
@@ -1,4 +1,6 @@
-gap> Read("tst/testpackage.g");;
+gap> testpackage := Filename( DirectoriesPackageLibrary( "DeepThought", "tst" ),
+>                             "testpackage.g" );;
+gap> Read(testpackage);;
 gap> coll := Collector(UnitriangularPcpGroup(3, 0));;
 gap> Test_DTP_functions(coll, true, 300, 500);
 true


### PR DESCRIPTION
Before, it was necessary to read `tst/testall.g` from the root directory of the package. That caused the test to fail when GAP is started with another current directory (see e.g. https://travis-ci.org/gap-system/gap-docker-pkg-tests-stable-4.9/jobs/426072195).

It will be useful to have this fix in time for GAP 4.10 release.